### PR TITLE
feat: Unified API for reading and writing node values

### DIFF
--- a/include/open62541pp/detail/traits.hpp
+++ b/include/open62541pp/detail/traits.hpp
@@ -31,6 +31,18 @@ template <typename T>
 using MemberTypeT = typename MemberType<T>::type;
 
 template <typename T, typename = void>
+struct IsContainer : std::false_type {};
+
+template <typename T>
+struct IsContainer<
+    T,
+    std::void_t<decltype(std::declval<T>().begin()), decltype(std::declval<T>().end())>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool IsContainerV = IsContainer<T>::value;
+
+template <typename T, typename = void>
 struct IsContiguousContainer : std::false_type {};
 
 template <typename T>

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -398,6 +398,13 @@ public:
         return services::readValue(connection(), id()).value();
     }
 
+    /// Read value from variable node.
+    /// The characteristic scalar or array is deduced from the value's type.
+    template <typename T>
+    T readValue() {
+        return readValue().template getValueCopy<T>();
+    }
+
     /// Read scalar value from variable node.
     template <typename T>
     T readValueScalar() {
@@ -529,6 +536,15 @@ public:
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
         services::writeValue(connection(), id(), value).value();
+        return *this;
+    }
+
+    /// Write value to variable node.
+    /// The characteristic scalar or array is deduced from the value's type.
+    template <typename T>
+    Node& writeValue(const T& value) {
+        // NOLINTNEXTLINE(*-const-cast), variant isn't modified, try to avoid copy
+        writeValue(Variant::fromValue<VariantPolicy::ReferenceIfPossible>(const_cast<T&>(value)));
         return *this;
     }
 


### PR DESCRIPTION
# Goal

Add a unified API for reading from and writing to values of nodes. The new functions `Node::readValue` resp. `Node::writeValue` deduce the required call (scalar or array) from the template type and call the current API. The goal is to simplify the current API by reducing verbosity to improve the user experience.

As a long-term goal this API aims to replace the current APIs with the `*Scalar` and `*Array` suffix, though they are not touched for now for the sake of staying backwards-compatible. 

# Code Examples

Given a scalar and an array-like variable...

```
double scalarValue = 1;
std::vector<double> arrayValue{1,2,3};
```

...some code of the current API...

```
node.writeValueScalar(scalarValue);
scalarValue = node.readValueScalar<double>();

node.writeValueArray(arrayValue);
arrayValue = node.readValueArray<double>();
```

...could then be rewritten like this...

```
node.writeValue(scalarValue);
scalarValue = node.readValue<double>();

node.writeValue(arrayValue);
arrayValue = node.readValue<std::vector<double>>();

// When reading values:
// Additional API option with output param to remove the need for specifying T
node.readValue(scalarValue);
node.readValue(arrayValue);
```



# Open Points

Reconsider how best to check for scalar or array. The code looks strange, which is mostly due to the background that a string is considered a scalar type.